### PR TITLE
Adding MJPEG to the formats supported

### DIFF
--- a/v4l2capture.c
+++ b/v4l2capture.c
@@ -507,11 +507,10 @@ static PyMethodDef Video_device_methods[] = {
        "set containing strings identifying the capabilities of the video "
        "device."},
   {"set_format", (PyCFunction)Video_device_set_format, METH_VARARGS,
-       "set_format(size_x, size_y, yuv420 = 0) -> size_x, size_y\n\n"
+       "set_format(size_x, size_y, pixel_format='RGB24') -> size_x, size_y\n\n"
        "Request the video device to set image size and format. The device may "
        "choose another size than requested and will return its choice. The "
-       "image format will be RGB24 if yuv420 is false (default) or YUV420 if "
-       "yuv420 is true."},
+       "pixel format may be either RGB24, YUV420 or MJPEG."},
   {"set_fps", (PyCFunction)Video_device_set_fps, METH_VARARGS,
        "set_fps(fps) -> fps \n\n"
        "Request the video device to set frame per seconds.The device may "
@@ -533,7 +532,7 @@ static PyMethodDef Video_device_methods[] = {
   {"read", (PyCFunction)Video_device_read, METH_VARARGS,
        "read(get_timestamp) -> string or tuple\n\n"
        "Reads image data from a buffer that has been filled by the video "
-       "device. The image data is in RGB or YUV420 format as decided by "
+       "device. The image data is in RGB24, YUV420 or MJPEG format as decided by "
        "'set_format'. The buffer is removed from the queue. Fails if no buffer "
        "is filled. Use select.select to check for filled buffers. If "
        "get_timestamp is true, a tuple is turned containing (sec, microsec, "

--- a/v4l2capture.c
+++ b/v4l2capture.c
@@ -16,6 +16,7 @@
 #include <linux/videodev2.h>
 #include <sys/mman.h>
 #include <string.h>
+#include <stdio.h> //Only used for debugging
 
 #ifdef USE_LIBV4L
 #include <libv4l2.h>
@@ -255,6 +256,19 @@ static PyObject *Video_device_set_fps(Video_device *self, PyObject *args)
   	return NULL;
   }
   return Py_BuildValue("i",setfps.parm.capture.timeperframe.denominator);
+}
+
+static PyObject *Video_device_get_format(Video_device *self)
+{
+
+	struct v4l2_format format;
+	format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	if(my_ioctl(self->fd, VIDIOC_G_FMT, &format))
+	{
+		return NULL;
+	}
+	return Py_BuildValue("ii", format.fmt.pix.width, format.fmt.pix.height);
+
 }
 
 static PyObject *Video_device_start(Video_device *self)
@@ -511,6 +525,8 @@ static PyMethodDef Video_device_methods[] = {
        "Request the video device to set image size and format. The device may "
        "choose another size than requested and will return its choice. The "
        "pixel format may be either RGB24, YUV420 or MJPEG."},
+  {"get_format", (PyCFunction)Video_device_get_format, METH_NOARGS,
+       "get_format() -> size_x, size_y\n\n"},
   {"set_fps", (PyCFunction)Video_device_set_fps, METH_VARARGS,
        "set_fps(fps) -> fps \n\n"
        "Request the video device to set frame per seconds.The device may "

--- a/v4l2capture.c
+++ b/v4l2capture.c
@@ -267,7 +267,32 @@ static PyObject *Video_device_get_format(Video_device *self)
 	{
 		return NULL;
 	}
-	return Py_BuildValue("ii", format.fmt.pix.width, format.fmt.pix.height);
+
+	PyObject *out = PyTuple_New(3);
+	PyTuple_SetItem(out, 0, PyInt_FromLong(format.fmt.pix.width));
+	PyTuple_SetItem(out, 1, PyInt_FromLong(format.fmt.pix.height));
+
+	PyObject *pixFormatStr = NULL;
+	switch(format.fmt.pix.pixelformat)
+	{
+	case V4L2_PIX_FMT_MJPEG:
+		pixFormatStr = PyString_FromString("MJPEG");
+		break;
+	case V4L2_PIX_FMT_RGB24:
+		pixFormatStr = PyString_FromString("RGB24");
+		break;
+	case V4L2_PIX_FMT_YUV420:
+		pixFormatStr = PyString_FromString("YUV420");
+		break;
+	case V4L2_PIX_FMT_YUYV:
+		pixFormatStr = PyString_FromString("YUYV");
+		break;
+	default:
+		pixFormatStr = PyString_FromString("Unknown");
+		break;
+	}
+	PyTuple_SetItem(out, 2, pixFormatStr);
+	return out;
 
 }
 


### PR DESCRIPTION
Originally, RGB24 and YUV420 was supported and selected using a boolean. I changed to use a string variable and added support for MJPEG. Decoding of the image is not part of this library I assume.
